### PR TITLE
Adding optional parameter version to SFTP::Session

### DIFF
--- a/lib/net/sftp/session.rb
+++ b/lib/net/sftp/session.rb
@@ -75,8 +75,9 @@ module Net; module SFTP
     #
     #   sftp = Net::SFTP::Session.new(ssh)
     #   sftp.loop { sftp.opening? }
-    def initialize(session, &block)
+    def initialize(session, version = nil, &block)
       @session    = session
+      @version    = version
       @input      = Net::SSH::Buffer.new
       self.logger = session.logger
       @state      = :closed
@@ -876,7 +877,7 @@ module Net; module SFTP
         channel.on_close(&method(:when_channel_closed))
         channel.on_process(&method(:when_channel_polled))
 
-        send_packet(FXP_INIT, :long, HIGHEST_PROTOCOL_VERSION_SUPPORTED)
+        send_packet(FXP_INIT, :long, @version || HIGHEST_PROTOCOL_VERSION_SUPPORTED)
       end
 
       # Called when the SSH server closes the underlying channel.

--- a/test/common.rb
+++ b/test/common.rb
@@ -36,8 +36,8 @@ class Net::SFTP::TestCase < Test::Unit::TestCase
       Net::SSH::Buffer.from(*args).to_s
     end
 
-    def sftp(options={})
-      @sftp ||= Net::SFTP::Session.new(connection(options))
+    def sftp(options={}, version=nil)
+      @sftp ||= Net::SFTP::Session.new(connection(options), version)
     end
 
     def expect_sftp_session(opts={})

--- a/test/test_session.rb
+++ b/test/test_session.rb
@@ -13,6 +13,14 @@ class SessionTest < Net::SFTP::TestCase
     end
   end
 
+  def test_passing_version_should_cause_same_version_to_be_passed_and_used
+    version = 3
+    expect_sftp_session :client_version => version, :server_version => version
+    assert_scripted { sftp({},version).connect! }
+    assert_equal version, sftp.protocol.version
+  end
+
+
   def test_v1_open_read_only_that_succeeds_should_invoke_callback
     expect_open("/path/to/file", "r", nil, :server_version => 1)
     assert_successful_open("/path/to/file")


### PR DESCRIPTION
### Description

This change is to add option version to SFTP session to override HIGHEST_PROTOCOL_VERSION_SUPPORTED during negotiation. This parameter is useful when SFTP server has bug which terminates the connection before version negotiation if correct version is not passed.
### Checklists

**Development and testing:**
- [ ] The code changed/moved as a part of this PR has been covered with tests
- [x] All tests related to the changed code pass in development

**Pre-release and code review:**
- [x] CI build is green
